### PR TITLE
Fix/login unknown email crash

### DIFF
--- a/tests/unit/test_login.py
+++ b/tests/unit/test_login.py
@@ -8,6 +8,10 @@ class TestLogin:
     Branch: fix/login-unknown-email-crash
     """
 
+    # -----------------
+    # SAD PATH
+    # -----------------
+
     @pytest.mark.parametrize("email", [
         "unknown@notfound.com",
         "",


### PR DESCRIPTION
Refactored tests: Using paramaterize() allowed me to avoid unused import of pytest and combine my edge case into my sad paths.

Second fix was to add back in missing annotation for Sad Paths