### PR TITLE
fix: block bookings exceeding competition's available places — closes #10

### DIFF
--- a/server.py
+++ b/server.py
@@ -73,6 +73,16 @@ def purchase_places():
             club=club
         ), 200
 
+    available_places = int(competition['numberOfPlaces'])
+
+    if places_required > available_places:
+        flash("Not enough places available.")
+        return render_template(
+            'booking.html',
+            competition=competition,
+            club=club
+        ), 200
+
     competition['numberOfPlaces'] = int(competition['numberOfPlaces']) - places_required
 
     club['points'] = str(

--- a/tests/unit/test_booking.py
+++ b/tests/unit/test_booking.py
@@ -153,3 +153,18 @@ class TestPurchaseValidation:
         response = make_booking("Future Classic", "She Lifts", places_requested)
         assert response.status_code == 200
         assert b"Cannot book more than 12 places." in response.data
+
+    @pytest.mark.parametrize("places_requested", [2, 5, 10])
+    def test_booking_blocked_when_exceeds_available_places(
+            self, make_booking, places_requested
+    ):
+        """
+        Booking must be blocked when places requested exceed
+        the competition's available places.
+        Almost Full Competition has 1 place. Simply Lift has 13 points.
+        Values 2, 5, 10 all pass the 12-place cap and points check —
+        isolating availability check only.
+        """
+        response = make_booking("Almost Full Competition", "Simply Lift", places_requested)
+        assert response.status_code == 200
+        assert b"Not enough places available." in response.data


### PR DESCRIPTION
## Summary
Adds a guard clause to purchase_places() preventing bookings when the
competition has insufficient places available. Previously, numberOfPlaces
could go negative with no error shown.

## Changes
### server.py
- Captures available_places before deduction
- Added guard clause: places_required > available_places returns booking.html
  with flash message "Not enough places available."
- Runs after points check, before deduction — completing the validation order:
  1. Club/competition lookup guard
  2. 12-place cap (Issue #4)
  3. Insufficient points (Issue #3)
  4. Available places ← added in this branch

### tests/unit/test_booking.py
- Added sad path: values 2, 5, 10 blocked against Almost Full Competition (1 place)
- Test data isolates availability check only — values pass 12-place cap and points check

## Test results
17 passed, 0 failed — 77% coverage

Closes #10