### PR TITLE
chore: restore GitHub issue templates for bug, feature and improvement

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "BUG: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: given
+    attributes:
+      label: Given
+      description: What is the starting state or context?
+    validations:
+      required: true
+  - type: textarea
+    id: when
+    attributes:
+      label: When
+      description: What action triggers the bug?
+    validations:
+      required: true
+  - type: textarea
+    id: then
+    attributes:
+      label: Then (actual behavior)
+      description: What actually happens?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: relevant_code
+    attributes:
+      label: Relevant code / route
+      description: Which function or route is affected?
+    validations:
+      required: false
+  - type: input
+    id: branch
+    attributes:
+      label: Branch name
+      placeholder: fix/descriptive-name
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "BUG: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: given
+    attributes:
+      label: Given
+      description: What is the starting state or context?
+    validations:
+      required: true
+  - type: textarea
+    id: when
+    attributes:
+      label: When
+      description: What action triggers the bug?
+    validations:
+      required: true
+  - type: textarea
+    id: then
+    attributes:
+      label: Then (actual behavior)
+      description: What actually happens?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: relevant_code
+    attributes:
+      label: Relevant code / route
+      description: Which function or route is affected?
+    validations:
+      required: false
+  - type: input
+    id: branch
+    attributes:
+      label: Branch name
+      placeholder: fix/descriptive-name
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,26 @@
+name: Improvement / Tech Debt
+description: Code quality, refactoring, or technical debt
+title: "IMPROVEMENT: "
+labels: ["improvement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs improving and why?
+    validations:
+      required: true
+  - type: textarea
+    id: changes
+    attributes:
+      label: Proposed changes
+      description: What specifically should change?
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Any additional context
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
Restores GitHub issue templates lost from the default QA branch.
Templates are required on the default branch for GitHub to display
them when creating new issues.

## Changes
### .github/ISSUE_TEMPLATE/
- bug_report.yml — Given/When/Then/Expected/Branch fields
- feature_request.yml — Given/When/Then/Expected/Notes/Branch fields
- improvement.yml — Description/Changes/Relevant code/Branch/Notes fields

## Why
Templates were present on early branches but not carried forward
to QA. Without them, issues can only be created as blank forms.