### PR TITLE
improvement: add FileNotFoundError handling to load_clubs() and load_competitions() — closes #30

### DIFF
--- a/server.py
+++ b/server.py
@@ -3,23 +3,25 @@ import json
 from flask import Flask,render_template,request,redirect,flash,url_for
 
 
-def loadClubs():
-    with open('clubs.json') as c:
-         listOfClubs = json.load(c)['clubs']
-         return listOfClubs
+def load_clubs():
+    try:
+        with open('clubs.json') as c:
+            return json.load(c)['clubs']
+    except FileNotFoundError:
+        return []
 
-
-def loadCompetitions():
-    with open('competitions.json') as comps:
-         listOfCompetitions = json.load(comps)['competitions']
-         return listOfCompetitions
-
+def load_competitions():
+    try:
+        with open('competitions.json') as comps:
+            return json.load(comps)['competitions']
+    except FileNotFoundError:
+        return []
 
 app = Flask(__name__)
 app.secret_key = 'something_special'
 
-competitions = loadCompetitions()
-clubs = loadClubs()
+competitions = load_competitions()
+clubs = load_clubs()
 
 @app.route('/')
 def index():

--- a/tests/unit/test_loading.py
+++ b/tests/unit/test_loading.py
@@ -1,0 +1,26 @@
+import pytest
+import server
+
+class TestDataLoading:
+    """
+    Unit tests for load_clubs() and load_competitions().
+
+    Issue #14: Add FileNotFoundError handling to data loading functions.
+    Branch: improvement/file-not-found-handling
+
+    Verifies that missing JSON files return empty lists instead of crashing.
+    """
+
+    @pytest.mark.parametrize("load_function", [
+        server.load_clubs,
+        server.load_competitions,
+    ])
+    def test_returns_empty_list_when_file_missing(self, monkeypatch, tmp_path, load_function):
+        """
+        If the JSON file is not found, the loading function should
+        return an empty list rather than raising FileNotFoundError.
+        Covers both load_clubs() and load_competitions().
+        """
+        monkeypatch.chdir(tmp_path)
+        result = load_function()
+        assert result == []


### PR DESCRIPTION
## Summary
Wraps JSON file loading in try/except FileNotFoundError.
Previously a missing clubs.json or competitions.json would crash
the server at startup with an unhandled exception.
PEP8 snake_case naming was also addressed in the same functions.

## Changes
### server.py
- load_clubs() now returns [] if clubs.json is not found
- load_competitions() now returns [] if competitions.json is not found
- loadClubs() → load_clubs() (PEP8)
- loadCompetitions() → load_competitions() (PEP8)
- listOfClubs → clubs (PEP8)
- listOfCompetitions → competitions (PEP8)

### tests/unit/test_loading.py
- New test file: TestDataLoading class
- Parametrized test covering both functions
- Uses tmp_path fixture to simulate missing files cleanly

## Test results
33 passed, 0 failed

Closes #30
Closes #27